### PR TITLE
Version 5

### DIFF
--- a/gwe-buildfile.json
+++ b/gwe-buildfile.json
@@ -10,5 +10,5 @@
   "post_build_cmds": [
     "rm install.sh supervisor.conf"
   ],
-  "version": "4"
+  "version": "5"
 }

--- a/gwe.build
+++ b/gwe.build
@@ -47,7 +47,7 @@ cat << __EOF__ > install.sh
 
 echo "Installing gmq_demo app..."
 set -x
-mkdir -p ${INSTALL_PATH}
+[ -d ${INSTALL_PATH} ] || mkdir -p ${INSTALL_PATH}
 cp gmq_demo.py ${INSTALL_PATH}/
 set +x
 echo "Installation complete."

--- a/specs/resources.yaml
+++ b/specs/resources.yaml
@@ -1,16 +1,22 @@
 ---
-resources:
-- alias: sine-data
-  format: string
-- alias: usage_report
-  format: string
-- alias: engine_report
-  format: string
-- alias: engine_fetch
-  format: string
-- alias: device_info
-  format: string
-- alias: update_interval
-  format: string
-- alias: fetch_status
-  format: string
+  sine-data:
+    format: string
+    settable: false
+  engine_fetch:
+    format: string
+    settable: true
+  update_interval:
+    format: string
+    settable: true
+  device_info:
+    format: string
+    settable: false
+  usage_report:
+    format: string
+    settable: false
+  fetch_status:
+    format: string
+    settable: false
+  engine_report:
+    format: string
+    settable: false


### PR DESCRIPTION
Update `resources.yaml` to conform to MurCLI 3.0 format.
Increment version.
Check for existence of `INSTALL_PATH` before running `mkdir -p ${INSTALL_PATH}`.